### PR TITLE
Update code to work with newer versions of docker and deno

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,21 +13,20 @@
 # ==============================================================================
 
 # Using bullseye-slim as baseline, to be able to use node based scripts.
-FROM debian:bullseye-slim as base
+FROM debian:bullseye-slim AS base
 
 # Label for ghcr.io
 LABEL org.opencontainers.image.source=https://github.com/bbs-io/synchronet-docker
 
 # RUN echo "Building on $(uname -m)"
 
-# Build Arguments - GH_TOKEN needed to determine current Deno version
-ARG GH_TOKEN
+# Build Arguments
 ARG DEBIAN_FRONTEND=noninteractive
 ONBUILD ARG DEBIAN_FRONTEND=noninteractive
 
 # Environment variables for use
 ENV TERM=xterm
-ENV DENO_DIR /sbbs-data/.deno
+ENV DENO_DIR=/sbbs-data/.deno
 ENV DENO_INSTALL_ROOT=$DENO_DIR/bin
 ENV SBBSCTRL=/sbbs/ctrl
 ENV SBBSEXEC=/sbbs/exec
@@ -96,8 +95,8 @@ RUN echo "\n--------------------------------------------------------\nChecking o
 
 # Build Synchronet - Install
 RUN cd ./install \
-    && sed -i.bak '/git/d' ./GNUmakefile \
-    && make RELEASE=1 NO_X=1 SBBSDIR=/sbbs install
+    && sed -i.bak '/git/d' ./install-sbbs.mk \
+    && make RELEASE=1 NO_X=1 SBBSDIR=/sbbs -f ./install-sbbs.mk install
 
 # Build Synchronet - Other executables (upgrade_*)
 RUN cd ./src/sbbs3 \

--- a/docker/Dockerfile.buildenv
+++ b/docker/Dockerfile.buildenv
@@ -1,7 +1,7 @@
 # docker build -t bbs-io/synchronet:buildenv -f docker/Dockerfile.buildenv ./docker
 
 # Using bullseye-slim as baseline, to be able to use node based scripts.
-FROM debian:bullseye-slim as build
+FROM debian:bullseye-slim AS build
 
 ENV TERM=xterm
 

--- a/docker/buildscripts/post-build.sh
+++ b/docker/buildscripts/post-build.sh
@@ -25,5 +25,3 @@ rm -rf /sbbs/3rdp
 rm -rf /sbbs/src
 rm -rf /sbbs/repo
 
-cd /sbbs/scripts
-deno -q vendor ./init.ts

--- a/docker/scripts/init.ts
+++ b/docker/scripts/init.ts
@@ -5,7 +5,7 @@ import {
 	ensureFileSync,
 	ensureDirSync,
 	ensureSymlinkSync,
-} from "https://deno.land/std@0.159.0/fs/mod.ts";
+} from "https://deno.land/std@0.224.0/fs/mod.ts";
 
 // get directory entries to start from
 const dirDist = Array.from(Deno.readDirSync("/sbbs/dist"));
@@ -157,7 +157,7 @@ async function checkAll() {
 	const f = Deno.openSync("/sbbs-data/lock");
 	try {
 		// attempt to lock file, single initialization at a time.
-		await Deno.flock(f.rid, true);
+		await f.lock();
 
 		ensureDirSync(`/sbbs-data/backup`);
 		ensureSymlinkSync(`/sbbs-data/backup`, `/backup`);
@@ -183,7 +183,7 @@ async function checkAll() {
 			upgrade(!!oldVersion);
 		}
 	} finally {
-		await Deno.funlock(f.rid).catch(() => {});
+		await f.unlock().catch(() => {});
 		await Deno.remove("/sbbs-data/lock").catch(() => {});
 	}
 }

--- a/docker/scripts/sbbs-init
+++ b/docker/scripts/sbbs-init
@@ -11,7 +11,6 @@ mkdir -p /sbbs-data/data
 
 # Run initialization
 sudo deno -q run \
-  --import-map $SCRIPTSDIR/vendor/import_map.json \
   --unstable --allow-run --allow-read --allow-write \
   $SCRIPTSDIR/init.ts || exit $?
 


### PR DESCRIPTION
I had a weird issue where my kube container started erroring out when I restarted it, which lead me down a rabbit hole of rebuilding it myself and modernising things to run the latest version of sbbs (3.20d).  I thought I'd push back the changes I did to get it to build:

- Fixed some syntax stuff in dockerfiles (vscode was complaining)
- The SBBS project renamed GNUmakefile to sbbs-install.mk. Handle  that.
- deno upgraded major versions, so  some code changes were needed.

I've never written TS or used deno, but I think I have figured it mostly out and the result is the same as what we got previously, except it works for the latest versions of stuff.  It let me built and run my container in kube successfully, at least.